### PR TITLE
Don't modify the sitewide collection

### DIFF
--- a/src/_layouts/cluster_resource.erb
+++ b/src/_layouts/cluster_resource.erb
@@ -10,7 +10,7 @@ layout: default
 
 <%= partial "cluster/header", locals: { cluster: cluster } %>
 <main class="revised-cluster-grid">
-  <% ctas.slice!(0, 4).each do |cta| %>
+  <% ctas[0..3].each do |cta| %>
     <%= render Cards::CallToAction.new(post: cta) %>
   <% end %>
 
@@ -24,7 +24,7 @@ layout: default
     <%= render Cards::Prompt.new(post: prompt) %>
   <% end %>
 
-  <% ctas.each do |cta| %>
+  <% ctas[4..].each do |cta| %>
     <%= render Cards::CallToAction.new(post: cta) %>
   <% end %>
 </main>


### PR DESCRIPTION
🟢 - Ready 

# Reason for Change 
We were inappropriately slicing resources (specifically calls to action) off of the global collection. Because the Resources cluster page was rendered first it meant they were no longer available to create their own individual pages.

## Description of Change
- Use a `range` instead of a `slice!`