### PR TITLE
684 remove small margin to the right of menu icon on mobile

### DIFF
--- a/src/_components/shared/navbar.erb
+++ b/src/_components/shared/navbar.erb
@@ -15,7 +15,7 @@
         id="menu-button"
         aria-expanded="false"
         aria-controls="nav-menu"
-        data-action="click->open-close#updateState" class="inline-block mr-1 h-[44px] flex items-center nav-menu-button">
+        data-action="click->open-close#updateState" class="inline-block md:mr-1 h-[44px] flex items-center nav-menu-button">
           <span id="menu-text">Menu</span>
           <%= svg "images/shared/menu-icon.svg",class: "fill-white ml-[0.25rem]" %>
         </button>


### PR DESCRIPTION
🟢 - Ready