### PR TITLE
Link fixes

### DIFF
--- a/frontend/styles/cluster.css
+++ b/frontend/styles/cluster.css
@@ -190,3 +190,12 @@
   width: var(--cluster-image-size);
   height: var(--cluster-image-size);
 }
+
+.media-credit:active,
+.media-credit:focus,
+.media-credit:focus-visible  {
+  outline-width: 0.15rem;
+  border-radius: 0px;
+  outline-style: dotted;
+  outline-color: #2ef853;
+}

--- a/frontend/styles/index.css
+++ b/frontend/styles/index.css
@@ -236,7 +236,7 @@ a:focus {
   outline-width: 0.2rem;
   border-radius: 0px;
   outline-style: dotted;
-  outline-color: #1fb23a;
+  outline-color: #2ef853;
 }
 
 .footer-logo-link .footer-logo-link:active,

--- a/src/_partials/nav/_social_links.erb
+++ b/src/_partials/nav/_social_links.erb
@@ -7,8 +7,8 @@
       <li>
         <%= link_to social_link.data.name,
           social_link.data.href,
-          class: "text-xl text-medium-grey mb-[26px] block hover:underline hover:underline-offset-2 nav-link",
-          class: "text-xl text-medium-grey mb-[13px] block hover:underline hover:underline-offset-2",
+          class: "text-xl text-medium-grey mb-[26px] block hover:underline hover:underline-offset-2",
+          class: "text-xl text-medium-grey mb-[13px] block hover:underline hover:underline-offset-2 nav-link",
           target: :_blank
         %>
       </li>


### PR DESCRIPTION
🟢 - Ready 

# Reason for Change 
Noticed some changes were not applied for: 
- social media links in nav menu
- tag button/links
- media credit links

## Description of Change
- made updates to the focus styling of those links
<img width="586" alt="Screenshot 2024-04-05 at 1 30 26 PM" src="https://github.com/beflagrant/Peoples-History-of-Tech/assets/12958413/ea40fb3e-9839-4427-a08b-27e62362e911">
<img width="313" alt="Screenshot 2024-04-05 at 1 36 12 PM" src="https://github.com/beflagrant/Peoples-History-of-Tech/assets/12958413/3836357c-6e1c-4f68-8f52-67b31995452b">
<img width="116" alt="Screenshot 2024-04-05 at 1 39 04 PM" src="https://github.com/beflagrant/Peoples-History-of-Tech/assets/12958413/a6c797f0-a6ca-4ead-a1e4-b7d06946edaa">

