### PR TITLE
Home page updates phase 2

### DIFF
--- a/frontend/styles/landing.css
+++ b/frontend/styles/landing.css
@@ -162,7 +162,7 @@
       }
 
       & > li:nth-child(3) {
-        @apply !mt-[154px] flex items-end;
+        @apply mt-[150px];
       }
 
       & > li:nth-child(5) {

--- a/frontend/styles/landing.css
+++ b/frontend/styles/landing.css
@@ -162,7 +162,7 @@
       }
 
       & > li:nth-child(3) {
-        @apply !mt-[160px] flex items-end;
+        @apply !mt-[154px] flex items-end;
       }
     }
 

--- a/frontend/styles/landing.css
+++ b/frontend/styles/landing.css
@@ -162,7 +162,7 @@
       }
 
       & > li:nth-child(3) {
-        @apply !mt-[160px] display items-end;
+        @apply !mt-[160px] flex items-end;
       }
     }
 

--- a/frontend/styles/landing.css
+++ b/frontend/styles/landing.css
@@ -158,7 +158,7 @@
 
     @media (min-width: 1365px) {
       & > li:nth-child(2) {
-        height: 485px;
+        @apply h-[485px];
       }
 
       & > li:nth-child(3) {

--- a/frontend/styles/landing.css
+++ b/frontend/styles/landing.css
@@ -157,6 +157,10 @@
     }
 
     @media (min-width: 1365px) {
+      & > li:nth-child(2) {
+        height: 600px;
+      }
+
       & > li:nth-child(3) {
         display: flex;
         align-items: end;

--- a/frontend/styles/landing.css
+++ b/frontend/styles/landing.css
@@ -164,6 +164,20 @@
       & > li:nth-child(3) {
         @apply !mt-[154px] flex items-end;
       }
+
+      & > li:nth-child(5) {
+        @apply !mt-[169px] flex items-end;
+      }
+    }
+
+    @media (min-width: 1025px) and (max-width: 1365px) {
+      & > li:nth-child(3) {
+        @apply mt-[140px];
+
+        figure .event-image {
+          @apply mt-0;
+        }
+      }
     }
 
   }

--- a/frontend/styles/landing.css
+++ b/frontend/styles/landing.css
@@ -172,7 +172,7 @@
 
     @media (min-width: 1025px) and (max-width: 1365px) {
       & > li:nth-child(3) {
-        @apply mt-[140px];
+        @apply mt-[130px];
       }
 
       & > li:nth-child(5) {

--- a/frontend/styles/landing.css
+++ b/frontend/styles/landing.css
@@ -166,17 +166,17 @@
       }
 
       & > li:nth-child(5) {
-        @apply !mt-[169px] flex items-end;
+        @apply !mt-[160px] flex items-end;
       }
     }
 
     @media (min-width: 1025px) and (max-width: 1365px) {
       & > li:nth-child(3) {
         @apply mt-[140px];
+      }
 
-        figure .event-image {
-          @apply mt-0;
-        }
+      & > li:nth-child(5) {
+        @apply mt-[140px];
       }
     }
 

--- a/frontend/styles/landing.css
+++ b/frontend/styles/landing.css
@@ -158,12 +158,11 @@
 
     @media (min-width: 1365px) {
       & > li:nth-child(2) {
-        height: 600px;
+        height: 485px;
       }
 
       & > li:nth-child(3) {
-        display: flex;
-        align-items: end;
+        @apply !mt-[160px] display items-end;
       }
     }
 
@@ -265,10 +264,9 @@
       & .wrapper.journal {
         @apply my-[60px];
       }
-      & .wrapper.event article {
-        @apply mt-[32px];
+      & .wrapper.event article, .wrapper.resource article {
+        @apply mt-[26px];
       }
-
     }
 
     & .wrapper {
@@ -314,7 +312,7 @@
 
 
   @media (min-width: 1025px) and (max-width: 1365px) {
-    li > .wrapper.event {
+    li > .wrapper.event, .wrapper.resource {
       gap: 0 !important;
     }
   }

--- a/frontend/styles/landing.css
+++ b/frontend/styles/landing.css
@@ -156,7 +156,7 @@
       }
     }
 
-    @media (min-width: 1475px) {
+    @media (min-width: 1365px) {
       & > li:nth-child(3) {
         display: flex;
         align-items: end;

--- a/frontend/styles/landing.css
+++ b/frontend/styles/landing.css
@@ -155,6 +155,14 @@
         margin-top: calc((220 / 884) * 100%);
       }
     }
+
+    @media (min-width: 1475px) {
+      & > li:nth-child(3) {
+        display: flex;
+        align-items: end;
+      }
+    }
+
   }
   ul > li.home {
     @apply w-full;

--- a/frontend/styles/landing.css
+++ b/frontend/styles/landing.css
@@ -211,6 +211,7 @@
       & .wrapper.participate article {
         @apply flex flex-col items-end text-right;
       }
+
       &:nth-child(even) {
         @apply items-start;
 
@@ -279,6 +280,12 @@
         @apply my-[60px];
       }
       & .wrapper.event article, .wrapper.resource article {
+        @apply mt-[45px];
+      }
+    }
+
+    @media (max-width: 1365px) {
+      & .wrapper.event article {
         @apply mt-[26px];
       }
     }

--- a/frontend/styles/landing.css
+++ b/frontend/styles/landing.css
@@ -159,6 +159,13 @@
   ul > li.home {
     @apply w-full;
 
+    @media (max-width: 1025px) {
+      & .quote-wrapper {
+        h2 {
+          @apply !text-left;
+        }
+      }
+    }
 
     @media (max-width: 1024px) {
       .thumbnail-desktop {
@@ -247,8 +254,9 @@
         @apply my-[60px];
       }
       & .wrapper.event article {
-        @apply mt-[50px];
+        @apply mt-[32px];
       }
+
     }
 
     & .wrapper {
@@ -262,6 +270,7 @@
     }
   }
 }
+
 @media (min-width: 1366px) {
   & .wrapper {
     flex-wrap: unset !important;
@@ -288,6 +297,13 @@
       column-gap: calc((100 / 1550) * 100%);
       grid-template-columns: repeat(2,minmax(46%,725px));
       grid-template-rows: auto;
+    }
+  }
+
+
+  @media (min-width: 1025px) and (max-width: 1365px) {
+    li > .wrapper.event {
+      gap: 0 !important;
     }
   }
 

--- a/src/_components/shared/resource.erb
+++ b/src/_components/shared/resource.erb
@@ -1,5 +1,5 @@
 <div class="wrapper resource">
-  <div class="hidden md:block">
+  <div class="block thumbnail-desktop">
     <%= render Resource::Thumbnail.new %>
   </div>
   <article class="w-full md:min-w-[200px] <%= @classname %> mt-[26px] md:mt-[50px] flex flex-col">
@@ -14,7 +14,7 @@
     <p class="base mb-[11px] md:mb-[21px]">
       <%= @entry.summary_summary(length: 350) %>
     </p>
-    <div class="block md:hidden flex mb-[16px] thumbnail">
+    <div class="block flex mb-[16px] thumbnail">
       <%= render Resource::Thumbnail.new %>
     </div>
     <%= render Resource::ClusterLink.new %>


### PR DESCRIPTION
🍏  Ready Go! Sherri has signed off on the updates. 

# Reason for Change 

1. thumbnail should be closer to the date at screen from 1025px to 1365 px range.

2. Quote should be left aligned from mobile, all the way up to 1025px

3. The space above and below the quote should be even. 


## Description of Change

1. Added breakpoint range from 1025px to 1365px to bring the event thumbnail and date closer. 

2. added css to make sure the quote is left aligned from mobile to 1025px

3.  So it looks like I am able have the event above the quote brush up against the top border of the quote. Also in the case if there is an event with a few words the image sets on top of that quote border as well. 

<img width="704" alt="Screenshot 2024-05-13 at 2 41 52 PM" src="https://github.com/EthicalSource/phot-the-mobile-phone/assets/12958413/bc27ec1f-a659-431d-92a2-94915b2260a0">
<img width="699" alt="Screenshot 2024-05-13 at 2 42 02 PM" src="https://github.com/EthicalSource/phot-the-mobile-phone/assets/12958413/7a361fae-4df9-41ef-a550-81c00ce77c2b">


 I believe we discussed also changing the height of that grid cell that holds the event. So that grid cell is also in the same row as the cluster header grid cell. Changing the height is also dependent on the cluster header grid cell height as well. I was playing around with editing the height of the grid cell. Thoughts? This is how it looks at 600px height. 
<img width="699" alt="Screenshot 2024-05-13 at 2 51 25 PM" src="https://github.com/EthicalSource/phot-the-mobile-phone/assets/12958413/2a4e38a2-643a-4b33-80cf-362e06e7ba71">
<img width="700" alt="Screenshot 2024-05-13 at 2 51 44 PM" src="https://github.com/EthicalSource/phot-the-mobile-phone/assets/12958413/2548f9cd-f6bd-4f70-9df5-6925a0718853">



